### PR TITLE
Mentees CRUD

### DIFF
--- a/app/controllers/mentees_controller.rb
+++ b/app/controllers/mentees_controller.rb
@@ -1,0 +1,54 @@
+class MenteesController < ApplicationController
+  before_action :set_mentee, only: [:edit, :update, :show, :destroy]
+
+  def index
+    @mentees = Mentee.all
+  end
+
+  def show
+    @mentee
+  end
+
+  def new
+    @mentee = Mentee.new
+  end  
+
+  def create
+    @mentee = Mentee.new(mentee_params)
+
+    if @mentee.save
+      redirect_to @mentee
+    else
+      render :new, status: :unprocessable_entity
+    end  
+  end
+
+  def edit
+    @mentee
+  end
+
+  def update
+    if @mentee.update(mentee_params)
+      redirect_to @mentee
+    else
+      render :edit, status: :unprocessable_entity
+    end
+    
+  end
+
+  def destroy
+    @mentee.destroy
+
+    redirect_to mentees_path, status: :see_other
+  end
+
+  private
+
+  def mentee_params
+    params.require(:mentee).permit(:name, :email, :bio)
+  end
+
+  def set_mentee
+    @mentee = Mentee.find(params[:id])
+  end
+end

--- a/app/views/mentees/_form.html.erb
+++ b/app/views/mentees/_form.html.erb
@@ -2,11 +2,17 @@
   <div>
     <%= form.label :name %><br>
     <%= form.text_field :name %>
+    <% @mentee.errors.full_messages_for(:name).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
   </div>
 
   <div>
     <%= form.label :email %><br>
     <%= form.text_field :email %>
+    <% @mentee.errors.full_messages_for(:email).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
   </div>
 
   <div>

--- a/app/views/mentees/_form.html.erb
+++ b/app/views/mentees/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: @mentee do |form| %>
+  <div>
+    <%= form.label :name %><br>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.label :email %><br>
+    <%= form.text_field :email %>
+  </div>
+
+  <div>
+    <%= form.label :bio %><br>
+    <%= form.text_area :bio %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/mentees/edit.html.erb
+++ b/app/views/mentees/edit.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1>Update Mentee</h1>
+  <%= render "form" %>
+</div>

--- a/app/views/mentees/index.html.erb
+++ b/app/views/mentees/index.html.erb
@@ -1,0 +1,15 @@
+<h1>Mentees</h1>
+
+<ul>
+  <% @mentees.each do |mentee| %>
+    <%= link_to mentee_path(mentee) do %>
+      <li>
+        <%= mentee.name %>
+        <%= mentee.bio %>
+        <%= mentee.email %>
+      </li>
+    <% end %>
+  <% end %>
+</ul>
+
+<%= link_to "New", new_mentee_path(@mentee) %>

--- a/app/views/mentees/new.html.erb
+++ b/app/views/mentees/new.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1>New Mentee</h1>
+  <%= render "form" %>
+</div>

--- a/app/views/mentees/show.html.erb
+++ b/app/views/mentees/show.html.erb
@@ -1,0 +1,14 @@
+<h1><%= @mentee.name %></h1>
+
+<p><%= @mentee.email %></p>
+<p><%= @mentee.bio %></p>
+
+<ul>
+  <li><%= link_to "Edit", edit_mentee_path(@mentee) %></li>
+  <li><%= link_to "Destroy", mentee_path(@mentee), data: {
+                    turbo_method: :delete,
+                    turbo_confirm: "Are you sure?"
+                  } %></li>
+</ul>
+
+<%= link_to "Home", mentees_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   end
   mount Sidekiq::Web => "/sidekiq"
 
+  resources :mentees
+
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/spec/requests/panel/mentees_spec.rb
+++ b/spec/requests/panel/mentees_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe "/mentees", type: :request do
+  describe "GET /index" do
+    it "renders a successful response" do
+      get mentees_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /show" do
+    it "renders a successful response" do
+      mentee = Mentee.create(name: "test", email: "test@example.com", bio: "mentee test bio")
+      get mentee_url(mentee)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_mentee_url
+      expect(response).to be_successful
+    end
+  end
+  
+  describe "POST /edit" do
+    it "renders a successful response" do
+      mentee = Mentee.create(name: "test", email: "test@example.com", bio: "mentee test bio")
+      get edit_mentee_url(mentee)
+      expect(response).to be_successful
+    end
+  end
+  
+  describe "POST /create" do
+    context "with valid params" do
+      it "renders a successful response" do
+        attributes = {name: "test", email: "test@example.com", bio: "mentee test bio"}
+        
+        expect{post mentees_url, params: {mentee: attributes}}.to change(Mentee, :count).by(1)
+      end
+
+      it "redirects to the created Mentee" do
+        attributes = {name: "test", email: "test@example.com", bio: "mentee test bio"}
+
+        post mentees_url, params: {mentee: attributes}
+        
+        expect(response).to redirect_to(mentee_url(Mentee.last))
+      end
+    end
+
+    context "with invalid params" do
+      it "renders a non successful response" do
+        attributes = {email: "test@example.com", bio: "mentee test bio"}
+        post mentees_url, params: {mentee: attributes}
+        
+        expect(response).not_to be_successful
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "destroys the requested mentee" do
+      mentee = Mentee.create(name: "test", email: "test@example.com", bio: "mentee test bio")
+
+      expect { delete mentee_url(mentee) }.to change(Mentee, :count).by(-1)
+    end
+
+    it "redirects to the mentees list" do
+      mentee = Mentee.create(name: "test", email: "test@example.com", bio: "mentee test bio")
+      delete mentee_url(mentee)
+      expect(response).to redirect_to(mentees_url)
+    end
+  end
+end


### PR DESCRIPTION
Criamos as rotas, controllers e views de todos os passos do CRUD para as mentoradas.

Temos a listagem de mentoradas, página de detalhes de cada mentoradas, formulários para criar e editar e a possibilidade de deletar uma mentorada.

Essa tarefa é necessária para o cadastro e gerenciamento de mentoradas na plataforma.

Ticket do Trello: https://trello.com/c/uOaGZi67/7-criar-crud-de-mentorandas

![image](https://github.com/RailsGirls-SP/mentorship/assets/82549482/fbe93a27-82d9-4e66-b968-3ef8fce03b74)
![image](https://github.com/RailsGirls-SP/mentorship/assets/82549482/15acb588-a69b-402f-af29-b99f4446e6a0)
![image](https://github.com/RailsGirls-SP/mentorship/assets/82549482/2811c834-3c52-44c5-8ae9-34d12f63944d)
